### PR TITLE
設定メニューと車両設定画面を追加

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -37,6 +37,15 @@ service cloud.firestore {
         && (!request.resource.data.permissions.keys().hasAll(['read']) || request.resource.data.permissions.read is list);
       allow list, get: if request.auth != null
         && request.auth.uid in resource.data.permissions.read;
+      allow update: if request.auth != null
+        && request.auth.uid in resource.data.permissions.write
+        && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['name', 'classes', 'permissions'])
+        && request.resource.data.classes is list
+        && request.resource.data.name is string
+        && request.resource.data.permissions is map
+        && request.resource.data.permissions.keys().hasOnly(['write', 'read'])
+        && (!request.resource.data.permissions.keys().hasAll(['write']) || request.resource.data.permissions.write is list)
+        && (!request.resource.data.permissions.keys().hasAll(['read']) || request.resource.data.permissions.read is list);
 
       match /trips/{tid} {
         allow get, list: if request.auth != null

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,14 @@ import type { User } from 'firebase/auth';
 import { getAuth, onAuthStateChanged } from 'firebase/auth';
 import { useEffect, useState } from 'react';
 import Auth from './components/Auth';
+import SettingsMenu from './components/SettingsMenu';
 import TripClassificater from './sections/TripClassificater';
+import VehicleSettings from './sections/VehicleSettings';
 import Loader from './components/Loader';
 
 export default function App() {
   const [currentUser, setCurrentUser] = useState<User | null | undefined>(undefined);
+  const [vehicleSettingsOpen, setVehicleSettingsOpen] = useState(false);
   const auth = getAuth();
 
   useEffect(() => onAuthStateChanged(auth, (user) => {
@@ -24,9 +27,16 @@ export default function App() {
         style={{ paddingTop: 'calc(0.375rem + env(safe-area-inset-top))' }}
       >
         <h2 className="font-bold grow text-white">Trip classificater</h2>
-        <Auth currentUser={currentUser} />
+        {currentUser ? (
+          <SettingsMenu currentUser={currentUser} onOpenVehicleSettings={() => setVehicleSettingsOpen(true)} />
+        ) : (
+          <Auth currentUser={currentUser} />
+        )}
       </nav>
       {currentUser && <TripClassificater currentUser={currentUser} />}
+      {currentUser && vehicleSettingsOpen && (
+        <VehicleSettings currentUser={currentUser} onClose={() => setVehicleSettingsOpen(false)} />
+      )}
     </main>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,11 @@ export default function App() {
     setCurrentUser(user);
   }), [auth]);
 
+  // ログアウト時に車両設定モーダルを閉じ、再ログイン時の意図しない再表示を防ぐ
+  useEffect(() => {
+    if (!currentUser) setVehicleSettingsOpen(false);
+  }, [currentUser]);
+
   if (currentUser === undefined) {
     return <Loader className="fixed inset-0 bg-slate-100 text-green-300 text-5xl" />;
   }

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -1,0 +1,83 @@
+import type { User } from 'firebase/auth';
+import { getAuth, signOut } from 'firebase/auth';
+import { useEffect, useState } from 'react';
+import DeleteAccount from './DeleteAccount';
+
+const local = process.env.NODE_ENV !== 'production';
+
+export default function SettingsMenu({
+  currentUser,
+  onOpenVehicleSettings,
+}: {
+  currentUser: User,
+  onOpenVehicleSettings: () => void,
+}) {
+  const [open, setOpen] = useState(false);
+
+  // メニューを開いている間に Esc キーで閉じられるようにする
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open]);
+
+  function handleVehicleSettings() {
+    setOpen(false);
+    onOpenVehicleSettings();
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-label="設定"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="shrink-0 w-9 h-9 flex items-center justify-center rounded-full text-white active:bg-lime-600"
+      >
+        {/* 歯車アイコン */}
+        <svg viewBox="0 0 24 24" className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+        </svg>
+      </button>
+
+      {open && (
+        <>
+          {/* メニュー外のタップで閉じるための透明な背面 */}
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div
+            role="menu"
+            className="absolute right-0 top-full mt-1 z-50 min-w-44 rounded-xl border border-gray-200 bg-white py-1 text-gray-800 shadow-lg"
+          >
+            <button
+              type="button"
+              role="menuitem"
+              onClick={handleVehicleSettings}
+              className="w-full text-left px-4 py-2.5 text-sm active:bg-gray-100"
+            >
+              車両設定
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => signOut(getAuth())}
+              className="w-full text-left px-4 py-2.5 text-sm text-red-700 active:bg-gray-100"
+            >
+              ログアウト
+            </button>
+            {local && (
+              <div className="border-t border-gray-100 mt-1 pt-1 px-4 py-1.5 text-sm text-red-700">
+                <DeleteAccount currentUser={currentUser} />
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/sections/TripClassificater.tsx
+++ b/src/sections/TripClassificater.tsx
@@ -1,5 +1,5 @@
 import type { User } from 'firebase/auth';
-import { getFirestore, onSnapshot, doc, addDoc, query, collection, writeBatch, getDoc, where, updateDoc, arrayUnion, Timestamp } from 'firebase/firestore';
+import { getFirestore, onSnapshot, doc, addDoc, query, collection, writeBatch, getDoc, where, updateDoc, Timestamp } from 'firebase/firestore';
 import { useEffect, useMemo, useState } from 'react';
 import NewTrip from './components/NewTrip';
 import { tripConverter, type Trip } from '../firestore/definitions/Trip';
@@ -179,17 +179,6 @@ export default function TripClassificater({ currentUser }: { currentUser: User }
     });
   }
 
-  function share() {
-    if (!currentVehicleId) return;
-    const id = prompt('共有相手のIDを入力してください');
-    if (id) {
-      updateDoc(doc(db, 'vehicles', currentVehicleId).withConverter(vehicleConverter), {
-        'permissions.read': arrayUnion(id),
-        'permissions.write': arrayUnion(id),
-      });
-    }
-  }
-
   // 却下時は理由を返し、フォーム側でユーザーに提示できるようにする
   function createTrip(trip: Trip): string | null {
     const prevTrip = [...calculatedTrips].reverse().find(({ timestamp }) => trip.timestamp.seconds > timestamp.seconds || trip.timestamp.seconds === timestamp.seconds && trip.timestamp.nanoseconds > timestamp.nanoseconds);
@@ -218,9 +207,6 @@ export default function TripClassificater({ currentUser }: { currentUser: User }
             ))}
           </select>
         </label>
-        <button className="shrink-0 text-sm text-blue-700 py-2 px-2" onClick={share}>
-          共有
-        </button>
       </section>
 
       {/* 年間集計（確認頻度は低いので折りたたみ） */}

--- a/src/sections/VehicleSettings.tsx
+++ b/src/sections/VehicleSettings.tsx
@@ -33,15 +33,35 @@ export default function VehicleSettings({
   // 対象車両の現在値を読み込み、フォームの初期値とする
   useEffect(() => {
     setLoaded(false);
-    if (!currentVehicleId) return;
-    const unsub = onSnapshot(doc(db, 'vehicles', currentVehicleId).withConverter(vehicleConverter), (snapshot) => {
-      const data = snapshot.data();
-      if (data) {
+    setError('');
+    if (!currentVehicleId) {
+      setName('');
+      setClasses([]);
+      return;
+    }
+    const unsub = onSnapshot(
+      doc(db, 'vehicles', currentVehicleId).withConverter(vehicleConverter),
+      (snapshot) => {
+        const data = snapshot.data();
+        if (!data) {
+          setName('');
+          setClasses([]);
+          setError('車両情報が見つかりません');
+          setLoaded(true);
+          return;
+        }
         setName(data.name);
         setClasses(data.classes);
-      }
-      setLoaded(true);
-    });
+        setLoaded(true);
+      },
+      // 権限/通信エラー時もローダーを解除し、画面が固まらないようにする
+      () => {
+        setName('');
+        setClasses([]);
+        setError('車両情報の読み込みに失敗しました');
+        setLoaded(true);
+      },
+    );
     return unsub;
   }, [currentVehicleId]);
 

--- a/src/sections/VehicleSettings.tsx
+++ b/src/sections/VehicleSettings.tsx
@@ -1,0 +1,178 @@
+import type { User } from 'firebase/auth';
+import { getFirestore, onSnapshot, doc, updateDoc } from 'firebase/firestore';
+import { useEffect, useState } from 'react';
+import { userConverter } from '../firestore/definitions/User';
+import { vehicleConverter } from '../firestore/definitions/Vehicle';
+import Loader from '../components/Loader';
+
+export default function VehicleSettings({
+  currentUser,
+  onClose,
+}: {
+  currentUser: User,
+  onClose: () => void,
+}) {
+  // initializeApp 後に評価されるよう、Firestore はコンポーネント内で取得する
+  const db = getFirestore();
+  const [currentVehicleId, setCurrentVehicleId] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [name, setName] = useState('');
+  // 走行種別（business / private など）のマスタ
+  const [classes, setClasses] = useState<string[]>([]);
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  // 現在選択中の車両 ID を取得する
+  useEffect(() => {
+    const unsub = onSnapshot(doc(db, 'users', currentUser.uid).withConverter(userConverter), (snapshot) => {
+      setCurrentVehicleId(snapshot.data()?.state.vehicle ?? null);
+    });
+    return unsub;
+  }, [currentUser]);
+
+  // 対象車両の現在値を読み込み、フォームの初期値とする
+  useEffect(() => {
+    setLoaded(false);
+    if (!currentVehicleId) return;
+    const unsub = onSnapshot(doc(db, 'vehicles', currentVehicleId).withConverter(vehicleConverter), (snapshot) => {
+      const data = snapshot.data();
+      if (data) {
+        setName(data.name);
+        setClasses(data.classes);
+      }
+      setLoaded(true);
+    });
+    return unsub;
+  }, [currentVehicleId]);
+
+  function updateClass(index: number, value: string) {
+    setClasses((prev) => prev.map((c, i) => (i === index ? value : c)));
+  }
+
+  function removeClass(index: number) {
+    setClasses((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function addClass() {
+    setClasses((prev) => [...prev, '']);
+  }
+
+  async function handleSave(event: React.FormEvent) {
+    event.preventDefault();
+    if (!currentVehicleId) return;
+    const trimmedName = name.trim();
+    // 空欄を除き、前後の空白を整理する
+    const trimmedClasses = classes.map((c) => c.trim()).filter((c) => c !== '');
+    if (!trimmedName) {
+      setError('車両名を入力してください');
+      return;
+    }
+    if (new Set(trimmedClasses).size !== trimmedClasses.length) {
+      setError('走行種別が重複しています');
+      return;
+    }
+    if (!trimmedClasses.length) {
+      setError('走行種別を1つ以上入力してください');
+      return;
+    }
+    setSaving(true);
+    setError('');
+    try {
+      await updateDoc(doc(db, 'vehicles', currentVehicleId).withConverter(vehicleConverter), {
+        name: trimmedName,
+        classes: trimmedClasses,
+      });
+      onClose();
+    } catch (e) {
+      setError('保存に失敗しました');
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-start bg-black/40"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        className="w-full bg-white rounded-b-2xl px-5 pb-5 max-h-full overflow-y-auto shadow-2xl"
+        style={{ paddingTop: 'calc(0.5rem + env(safe-area-inset-top))' }}
+      >
+        <h3 className="text-base font-bold text-center py-1">車両設定</h3>
+
+        {!currentVehicleId ? (
+          <p className="text-center text-sm text-gray-500 py-8">車両が選択されていません</p>
+        ) : !loaded ? (
+          <Loader className="text-lime-500 text-3xl py-8" />
+        ) : (
+          <form className="space-y-5" onSubmit={handleSave}>
+            {/* 車両名 */}
+            <label className="block">
+              <span className="text-xs font-medium text-gray-600">車両名</span>
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                type="text"
+                className="w-full text-lg font-medium border-b-2 border-lime-500 bg-transparent focus:outline-none py-1"
+              />
+            </label>
+
+            {/* 走行種別マスタ */}
+            <div>
+              <span className="text-xs font-medium text-gray-600">走行種別</span>
+              <ul className="space-y-2 mt-1">
+                {classes.map((cls, index) => (
+                  <li key={index} className="flex items-center gap-2">
+                    <input
+                      value={cls}
+                      onChange={(e) => updateClass(index, e.target.value)}
+                      type="text"
+                      placeholder="例: business / private"
+                      className="grow text-base border rounded-lg px-3 py-2 border-gray-300 focus:outline-none focus:border-lime-500"
+                    />
+                    <button
+                      type="button"
+                      aria-label="削除"
+                      onClick={() => removeClass(index)}
+                      className="shrink-0 w-9 h-9 flex items-center justify-center rounded-full border border-gray-300 text-gray-500 active:bg-gray-100"
+                    >
+                      ✕
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <button
+                type="button"
+                onClick={addClass}
+                className="mt-2 text-sm text-lime-700 font-medium active:text-lime-800"
+              >
+                ＋ 走行種別を追加
+              </button>
+            </div>
+
+            {/* エラー表示 */}
+            {error && <p className="text-sm text-red-600 text-center" role="alert">{error}</p>}
+
+            {/* 操作 */}
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex-1 border-2 border-gray-300 text-gray-600 rounded-xl py-2.5 font-medium active:bg-gray-100"
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                disabled={saving}
+                className="flex-1 bg-lime-500 text-white rounded-xl py-2.5 font-bold shadow active:bg-lime-600 disabled:opacity-60"
+              >
+                保存する
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/sections/VehicleSettings.tsx
+++ b/src/sections/VehicleSettings.tsx
@@ -17,8 +17,9 @@ export default function VehicleSettings({
   const [currentVehicleId, setCurrentVehicleId] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [name, setName] = useState('');
-  // 走行種別（business / private など）のマスタ
-  const [classes, setClasses] = useState<string[]>([]);
+  // 走行種別（business / private など）のマスタ。
+  // 削除・並び替え時に入力状態がずれないよう、各項目に安定した id を持たせる
+  const [classes, setClasses] = useState<{ id: string, value: string }[]>([]);
   const [error, setError] = useState('');
   const [saving, setSaving] = useState(false);
 
@@ -51,7 +52,7 @@ export default function VehicleSettings({
           return;
         }
         setName(data.name);
-        setClasses(data.classes);
+        setClasses(data.classes.map((value) => ({ id: crypto.randomUUID(), value })));
         setLoaded(true);
       },
       // 権限/通信エラー時もローダーを解除し、画面が固まらないようにする
@@ -65,27 +66,30 @@ export default function VehicleSettings({
     return unsub;
   }, [currentVehicleId]);
 
-  function updateClass(index: number, value: string) {
-    setClasses((prev) => prev.map((c, i) => (i === index ? value : c)));
+  function updateClass(id: string, value: string) {
+    setClasses((prev) => prev.map((c) => (c.id === id ? { ...c, value } : c)));
   }
 
-  function removeClass(index: number) {
-    setClasses((prev) => prev.filter((_, i) => i !== index));
+  function removeClass(id: string) {
+    setClasses((prev) => prev.filter((c) => c.id !== id));
   }
 
   function addClass() {
-    setClasses((prev) => [...prev, '']);
+    setClasses((prev) => [...prev, { id: crypto.randomUUID(), value: '' }]);
   }
 
   // 共有は権限の追加であり、フォームの保存とは独立してその場で反映する
-  function share() {
+  async function share() {
     if (!currentVehicleId) return;
     const id = prompt('共有相手のIDを入力してください');
-    if (id) {
-      updateDoc(doc(db, 'vehicles', currentVehicleId).withConverter(vehicleConverter), {
-        'permissions.read': arrayUnion(id),
-        'permissions.write': arrayUnion(id),
+    if (!id?.trim()) return;
+    try {
+      await updateDoc(doc(db, 'vehicles', currentVehicleId).withConverter(vehicleConverter), {
+        'permissions.read': arrayUnion(id.trim()),
+        'permissions.write': arrayUnion(id.trim()),
       });
+    } catch {
+      setError('共有の追加に失敗しました');
     }
   }
 
@@ -94,7 +98,7 @@ export default function VehicleSettings({
     if (!currentVehicleId) return;
     const trimmedName = name.trim();
     // 空欄を除き、前後の空白を整理する
-    const trimmedClasses = classes.map((c) => c.trim()).filter((c) => c !== '');
+    const trimmedClasses = classes.map((c) => c.value.trim()).filter((c) => c !== '');
     if (!trimmedName) {
       setError('車両名を入力してください');
       return;
@@ -153,11 +157,11 @@ export default function VehicleSettings({
             <div>
               <span className="text-xs font-medium text-gray-600">走行種別</span>
               <ul className="space-y-2 mt-1">
-                {classes.map((cls, index) => (
-                  <li key={index} className="flex items-center gap-2">
+                {classes.map((cls) => (
+                  <li key={cls.id} className="flex items-center gap-2">
                     <input
-                      value={cls}
-                      onChange={(e) => updateClass(index, e.target.value)}
+                      value={cls.value}
+                      onChange={(e) => updateClass(cls.id, e.target.value)}
                       type="text"
                       placeholder="例: business / private"
                       className="grow text-base border rounded-lg px-3 py-2 border-gray-300 focus:outline-none focus:border-lime-500"
@@ -165,7 +169,7 @@ export default function VehicleSettings({
                     <button
                       type="button"
                       aria-label="削除"
-                      onClick={() => removeClass(index)}
+                      onClick={() => removeClass(cls.id)}
                       className="shrink-0 w-9 h-9 flex items-center justify-center rounded-full border border-gray-300 text-gray-500 active:bg-gray-100"
                     >
                       ✕

--- a/src/sections/VehicleSettings.tsx
+++ b/src/sections/VehicleSettings.tsx
@@ -1,5 +1,5 @@
 import type { User } from 'firebase/auth';
-import { getFirestore, onSnapshot, doc, updateDoc } from 'firebase/firestore';
+import { getFirestore, onSnapshot, doc, updateDoc, arrayUnion } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { userConverter } from '../firestore/definitions/User';
 import { vehicleConverter } from '../firestore/definitions/Vehicle';
@@ -75,6 +75,18 @@ export default function VehicleSettings({
 
   function addClass() {
     setClasses((prev) => [...prev, '']);
+  }
+
+  // 共有は権限の追加であり、フォームの保存とは独立してその場で反映する
+  function share() {
+    if (!currentVehicleId) return;
+    const id = prompt('共有相手のIDを入力してください');
+    if (id) {
+      updateDoc(doc(db, 'vehicles', currentVehicleId).withConverter(vehicleConverter), {
+        'permissions.read': arrayUnion(id),
+        'permissions.write': arrayUnion(id),
+      });
+    }
   }
 
   async function handleSave(event: React.FormEvent) {
@@ -167,6 +179,18 @@ export default function VehicleSettings({
                 className="mt-2 text-sm text-lime-700 font-medium active:text-lime-800"
               >
                 ＋ 走行種別を追加
+              </button>
+            </div>
+
+            {/* 共有 */}
+            <div>
+              <span className="text-xs font-medium text-gray-600">共有</span>
+              <button
+                type="button"
+                onClick={share}
+                className="mt-1 block text-sm text-blue-700 font-medium active:text-blue-800"
+              >
+                ＋ 共有相手を追加
               </button>
             </div>
 

--- a/src/sections/VehicleSettings.tsx
+++ b/src/sections/VehicleSettings.tsx
@@ -1,6 +1,6 @@
 import type { User } from 'firebase/auth';
 import { getFirestore, onSnapshot, doc, updateDoc, arrayUnion } from 'firebase/firestore';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { userConverter } from '../firestore/definitions/User';
 import { vehicleConverter } from '../firestore/definitions/Vehicle';
 import Loader from '../components/Loader';
@@ -22,6 +22,8 @@ export default function VehicleSettings({
   const [classes, setClasses] = useState<{ id: string, value: string }[]>([]);
   const [error, setError] = useState('');
   const [saving, setSaving] = useState(false);
+  // フォームへ初期値を反映済みかどうか。編集中の外部更新で入力が失われるのを防ぐ
+  const initialized = useRef(false);
 
   // 現在選択中の車両 ID を取得する
   useEffect(() => {
@@ -35,6 +37,7 @@ export default function VehicleSettings({
   useEffect(() => {
     setLoaded(false);
     setError('');
+    initialized.current = false;
     if (!currentVehicleId) {
       setName('');
       setClasses([]);
@@ -43,6 +46,9 @@ export default function VehicleSettings({
     const unsub = onSnapshot(
       doc(db, 'vehicles', currentVehicleId).withConverter(vehicleConverter),
       (snapshot) => {
+        // 初回のみフォームへ反映する。共有操作などで snapshot が再発火しても
+        // 編集中の入力を上書きしないようにする
+        if (initialized.current) return;
         const data = snapshot.data();
         if (!data) {
           setName('');
@@ -51,6 +57,7 @@ export default function VehicleSettings({
           setLoaded(true);
           return;
         }
+        initialized.current = true;
         setName(data.name);
         setClasses(data.classes.map((value) => ({ id: crypto.randomUUID(), value })));
         setLoaded(true);

--- a/test/firestore-rules.spec.ts
+++ b/test/firestore-rules.spec.ts
@@ -269,6 +269,46 @@ describe('Firestore security rules', () => {
         assertFails(getDoc(doc(env.authenticatedContext(crypto.randomUUID().replace('-', '')).firestore(), 'vehicles', vid))),
       ]);
     });
+    test('a write permitted user can update name and classes', async () => {
+      await Promise.all([
+        assertSucceeds(updateDoc(doc(env.authenticatedContext(uid).firestore(), 'vehicles', vid), {
+          name: 'クラウン',
+          classes: ['Business', 'Private', 'Commute'],
+        })),
+        assertSucceeds(updateDoc(doc(env.authenticatedContext(writeOnlyUid).firestore(), 'vehicles', vid), {
+          name: 'プリウス',
+        })),
+        assertSucceeds(updateDoc(doc(env.authenticatedContext(uid).firestore(), 'vehicles', vid), {
+          'permissions.read': [uid, readOnlyUid, crypto.randomUUID().replace('-', '')],
+        })),
+      ]);
+    });
+    test('update with incorrect values should be denied', async () => {
+      await Promise.all([
+        assertFails(updateDoc(doc(env.authenticatedContext(uid).firestore(), 'vehicles', vid), {
+          name: 123,
+        })),
+        assertFails(updateDoc(doc(env.authenticatedContext(uid).firestore(), 'vehicles', vid), {
+          classes: 'NotAList',
+        })),
+        assertFails(updateDoc(doc(env.authenticatedContext(uid).firestore(), 'vehicles', vid), {
+          unapproved: 'value',
+        })),
+        assertFails(updateDoc(doc(env.authenticatedContext(uid).firestore(), 'vehicles', vid), {
+          'permissions.write': 'uid',
+        })),
+      ]);
+    });
+    test('a read only user cannot update a vehicle', async () => {
+      await assertFails(updateDoc(doc(env.authenticatedContext(readOnlyUid).firestore(), 'vehicles', vid), {
+        name: 'カムリ',
+      }));
+    });
+    test('an unauthenticated user cannot update a vehicle', async () => {
+      await assertFails(updateDoc(doc(env.unauthenticatedContext().firestore(), 'vehicles', vid), {
+        name: 'カムリ',
+      }));
+    });
 
     describe('in trips collection', () => {
       test('new trip by a permitted user should be accepted', async () => {


### PR DESCRIPTION
- トップバー右上に歯車の設定ボタンを配置し、タップで設定メニューを開く
- 設定メニューに車両設定とログアウトを追加（dev環境のみアカウント削除）
- 車両設定画面で車両名と走行種別マスタ（classes）を編集可能に
- 車両ドキュメントのupdateを許可するFirestoreルールと対応テストを追加

https://claude.ai/code/session_016j1wRiA14rk1tjWfpWJgAd