### PR TITLE
Vercel Postgres へのスキーマ・シード・CI を追加

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -12,6 +12,10 @@ name: Database
       - 'db/**'
       - '.github/workflows/database.yml'
 
+# This workflow only reads the repository; deny everything else by default.
+permissions:
+  contents: read
+
 jobs:
   schema:
     name: Apply schema, seed and smoke tests
@@ -39,6 +43,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Apply schema
         run: psql "$POSTGRES_URL" -v ON_ERROR_STOP=1 -f db/schema.sql

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -1,0 +1,56 @@
+name: Database
+
+'on':
+  push:
+    branches:
+      - main
+    paths:
+      - 'db/**'
+      - '.github/workflows/database.yml'
+  pull_request:
+    paths:
+      - 'db/**'
+      - '.github/workflows/database.yml'
+
+jobs:
+  schema:
+    name: Apply schema, seed and smoke tests
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: records_classificater_test
+        ports:
+          - 5432:5432
+        # Wait until Postgres is ready before the job starts using it.
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # Mirrors the connection string Vercel Postgres exposes as POSTGRES_URL.
+      POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/records_classificater_test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply schema
+        run: psql "$POSTGRES_URL" -v ON_ERROR_STOP=1 -f db/schema.sql
+
+      - name: Load seed data
+        run: psql "$POSTGRES_URL" -v ON_ERROR_STOP=1 -f db/seed.sql
+
+      - name: Run smoke tests
+        run: psql "$POSTGRES_URL" -v ON_ERROR_STOP=1 -f db/test/smoke.sql
+
+      - name: Verify reset + re-apply is repeatable
+        run: |
+          psql "$POSTGRES_URL" -v ON_ERROR_STOP=1 -f db/reset.sql
+          psql "$POSTGRES_URL" -v ON_ERROR_STOP=1 -f db/schema.sql
+          psql "$POSTGRES_URL" -v ON_ERROR_STOP=1 -f db/seed.sql

--- a/db/README.md
+++ b/db/README.md
@@ -38,7 +38,7 @@ exactly what Vercel Postgres provisions. Pull it locally with:
 
 ```sh
 vercel env pull .env.local   # provides POSTGRES_URL
-export $(grep POSTGRES_URL .env.local)
+export POSTGRES_URL="$(grep '^POSTGRES_URL=' .env.local | cut -d '=' -f2-)"
 ```
 
 Then:

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,60 @@
+# Database (Vercel Postgres)
+
+Relational schema for records-classificater, used after migrating off
+Firebase/Firestore to [Vercel Postgres](https://vercel.com/docs/storage/vercel-postgres).
+
+## Files
+
+| File               | Purpose                                                        |
+| ------------------ | ------------------------------------------------------------- |
+| `schema.sql`       | Table definitions. Drop-free, safe to apply once to a new DB. |
+| `seed.sql`         | Deterministic seed data for tests and local development.      |
+| `reset.sql`        | Drops every table so the schema can be re-applied (dev/CI).   |
+| `test/smoke.sql`   | Assertions over the schema constraints and seed data.         |
+
+## Data model
+
+The Firestore collections map to tables as follows:
+
+| Firestore                    | Postgres                                              |
+| ---------------------------- | ----------------------------------------------------- |
+| `users/{uid}`                | `users` (`current_vehicle_id` was `state.vehicle`)    |
+| `vehicles/{vid}`             | `vehicles` + `vehicle_classes` + `vehicle_permissions`|
+| `vehicles/{vid}/trips/{tid}` | `trips` (`recorded_at` was `timestamp`)               |
+
+- User ids are the auth provider's uid, stored as `TEXT`. They are not foreign
+  keys to `users`, because a vehicle can be shared with a user who has no
+  application state row yet (as in Firestore).
+- `permissions.read` / `permissions.write` arrays become per-user boolean
+  columns on `vehicle_permissions`; read and write remain independent.
+- The `classes` array becomes `vehicle_classes` (ordered by `position`). The
+  composite foreign key from `trips` enforces that a trip's `class` is one of
+  its vehicle's classes — the same invariant the Firestore rules enforced.
+
+## Usage
+
+These scripts call `psql` and expect a `POSTGRES_URL` connection string, which is
+exactly what Vercel Postgres provisions. Pull it locally with:
+
+```sh
+vercel env pull .env.local   # provides POSTGRES_URL
+export $(grep POSTGRES_URL .env.local)
+```
+
+Then:
+
+```sh
+npm run db:schema   # create tables
+npm run db:seed     # load seed data
+npm run db:reset    # drop, recreate, and reseed (dev/CI only)
+npm run db:test     # schema + seed + smoke tests on a fresh database
+```
+
+> `db:reset` and `db:test` are destructive — never point `POSTGRES_URL` at a
+> production database when running them.
+
+## CI
+
+`.github/workflows/database.yml` runs on changes under `db/`. It boots a
+`postgres:16` service, applies `schema.sql`, loads `seed.sql`, runs the smoke
+tests, and verifies that `reset.sql` makes the whole thing repeatable.

--- a/db/reset.sql
+++ b/db/reset.sql
@@ -1,0 +1,9 @@
+-- Drop every application table so the schema can be re-applied from scratch.
+-- Intended for local development and CI only -- never run this against a
+-- production database. `db/schema.sql` itself is kept drop-free so it stays
+-- safe to apply once to a fresh Vercel Postgres database.
+DROP TABLE IF EXISTS trips               CASCADE;
+DROP TABLE IF EXISTS users               CASCADE;
+DROP TABLE IF EXISTS vehicle_permissions CASCADE;
+DROP TABLE IF EXISTS vehicle_classes     CASCADE;
+DROP TABLE IF EXISTS vehicles            CASCADE;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -78,5 +78,3 @@ CREATE TABLE trips (
   UNIQUE (vehicle_id, odo),
   UNIQUE (vehicle_id, recorded_at)
 );
-
-CREATE INDEX idx_trips_vehicle_recorded ON trips (vehicle_id, recorded_at);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,82 @@
+-- Schema for records-classificater on Vercel Postgres.
+--
+-- This is the relational translation of the original Firestore model:
+--
+--   users/{uid}                 -> users
+--   vehicles/{vid}              -> vehicles + vehicle_classes + vehicle_permissions
+--   vehicles/{vid}/trips/{tid}  -> trips
+--
+-- User identifiers (`users.id`, `vehicle_permissions.user_id`) are the
+-- authentication provider's uid. They are stored as TEXT and are NOT foreign
+-- keys to `users`, because a vehicle can be shared with a user before that user
+-- has any application state row (mirrors Firestore, where a uid may appear in a
+-- vehicle's permissions without a `users/{uid}` document existing).
+
+-- gen_random_uuid() is built into PostgreSQL 13+; keep the extension for safety
+-- on older servers. Harmless on Vercel Postgres (Neon, PG 15/16).
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Vehicles --------------------------------------------------------------------
+CREATE TABLE vehicles (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name       TEXT        NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Trip classes available for a vehicle (was the `classes` string array).
+-- `position` preserves the display order the UI relies on for its color
+-- palette. The (vehicle_id, class) unique key is the target of the trips FK so
+-- that a trip can only use a class defined on its own vehicle.
+CREATE TABLE vehicle_classes (
+  vehicle_id UUID    NOT NULL REFERENCES vehicles (id) ON DELETE CASCADE,
+  class      TEXT    NOT NULL,
+  position   INTEGER NOT NULL,
+  PRIMARY KEY (vehicle_id, class),
+  UNIQUE (vehicle_id, position)
+);
+
+-- Per-user read/write permissions (was the `permissions.read` / `.write`
+-- arrays). read and write are independent: a user may have write without read,
+-- matching the original security rules.
+CREATE TABLE vehicle_permissions (
+  vehicle_id UUID    NOT NULL REFERENCES vehicles (id) ON DELETE CASCADE,
+  user_id    TEXT    NOT NULL,
+  can_read   BOOLEAN NOT NULL DEFAULT FALSE,
+  can_write  BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (vehicle_id, user_id),
+  CHECK (can_read OR can_write)
+);
+
+-- Look up "which vehicles can this user see/edit?" without scanning.
+CREATE INDEX idx_vehicle_permissions_user ON vehicle_permissions (user_id);
+
+-- Users -----------------------------------------------------------------------
+-- Application state for an authenticated user. `current_vehicle_id` is the
+-- vehicle currently selected in the UI (was `state.vehicle`).
+CREATE TABLE users (
+  id                 TEXT        PRIMARY KEY,
+  current_vehicle_id UUID        REFERENCES vehicles (id) ON DELETE SET NULL,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Trips -----------------------------------------------------------------------
+-- A single odometer reading for a vehicle. `recorded_at` is the moment the trip
+-- was logged (was the Firestore `timestamp`). The composite FK enforces that
+-- `class` is one of the vehicle's defined classes, as the security rules did.
+CREATE TABLE trips (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  vehicle_id  UUID        NOT NULL,
+  class       TEXT        NOT NULL,
+  odo         NUMERIC     NOT NULL CHECK (odo >= 0),
+  recorded_at TIMESTAMPTZ NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  FOREIGN KEY (vehicle_id, class)
+    REFERENCES vehicle_classes (vehicle_id, class) ON DELETE CASCADE,
+  -- The odometer is monotonic per vehicle, so both odo and time are unique.
+  UNIQUE (vehicle_id, odo),
+  UNIQUE (vehicle_id, recorded_at)
+);
+
+CREATE INDEX idx_trips_vehicle_recorded ON trips (vehicle_id, recorded_at);

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,0 +1,42 @@
+-- Deterministic seed data for tests and local development.
+--
+-- The fixed UUIDs and user ids below are stable so tests can reference them
+-- directly. The shape mirrors test/firestore-rules.spec.ts: one fully shared
+-- vehicle (owner + read-only + write-only users) and one private vehicle.
+--
+-- User ids (authentication uids):
+--   user-owner   -- read + write on both vehicles
+--   user-reader  -- read only on the カローラ
+--   user-writer  -- write only on the カローラ
+--
+-- Insert order respects foreign keys:
+--   vehicles -> vehicle_classes -> vehicle_permissions -> users -> trips
+
+INSERT INTO vehicles (id, name) VALUES
+  ('11111111-1111-1111-1111-111111111111', 'カローラ'),
+  ('22222222-2222-2222-2222-222222222222', 'ランサー');
+
+INSERT INTO vehicle_classes (vehicle_id, class, position) VALUES
+  ('11111111-1111-1111-1111-111111111111', 'Business', 0),
+  ('11111111-1111-1111-1111-111111111111', 'Private',  1),
+  ('22222222-2222-2222-2222-222222222222', 'Commute',  0),
+  ('22222222-2222-2222-2222-222222222222', 'Leisure',  1);
+
+INSERT INTO vehicle_permissions (vehicle_id, user_id, can_read, can_write) VALUES
+  ('11111111-1111-1111-1111-111111111111', 'user-owner',  TRUE,  TRUE),
+  ('11111111-1111-1111-1111-111111111111', 'user-reader', TRUE,  FALSE),
+  ('11111111-1111-1111-1111-111111111111', 'user-writer', FALSE, TRUE),
+  ('22222222-2222-2222-2222-222222222222', 'user-owner',  TRUE,  TRUE);
+
+INSERT INTO users (id, current_vehicle_id) VALUES
+  ('user-owner',  '11111111-1111-1111-1111-111111111111'),
+  ('user-reader', '11111111-1111-1111-1111-111111111111'),
+  ('user-writer', '11111111-1111-1111-1111-111111111111');
+
+-- Trips with a strictly increasing odometer over time, per vehicle.
+INSERT INTO trips (id, vehicle_id, class, odo, recorded_at) VALUES
+  ('aaaaaaaa-0000-0000-0000-000000000001', '11111111-1111-1111-1111-111111111111', 'Business', 10.0,  '2026-01-05T08:00:00+09:00'),
+  ('aaaaaaaa-0000-0000-0000-000000000002', '11111111-1111-1111-1111-111111111111', 'Private',  42.5,  '2026-01-05T18:30:00+09:00'),
+  ('aaaaaaaa-0000-0000-0000-000000000003', '11111111-1111-1111-1111-111111111111', 'Business', 123.4, '2026-01-06T09:15:00+09:00'),
+  ('bbbbbbbb-0000-0000-0000-000000000001', '22222222-2222-2222-2222-222222222222', 'Commute',  5.0,   '2026-02-01T07:45:00+09:00'),
+  ('bbbbbbbb-0000-0000-0000-000000000002', '22222222-2222-2222-2222-222222222222', 'Leisure',  88.8,  '2026-02-03T12:00:00+09:00');

--- a/db/test/smoke.sql
+++ b/db/test/smoke.sql
@@ -1,0 +1,78 @@
+-- Smoke tests for the schema + seed. Run with `psql -v ON_ERROR_STOP=1` after
+-- applying db/schema.sql and db/seed.sql; any RAISE EXCEPTION fails the run.
+
+\set ON_ERROR_STOP on
+
+-- 1. Seed loaded the expected number of rows. -------------------------------
+DO $$
+BEGIN
+  ASSERT (SELECT count(*) FROM vehicles) = 2,            'expected 2 vehicles';
+  ASSERT (SELECT count(*) FROM vehicle_classes) = 4,     'expected 4 vehicle_classes';
+  ASSERT (SELECT count(*) FROM vehicle_permissions) = 4, 'expected 4 vehicle_permissions';
+  ASSERT (SELECT count(*) FROM users) = 3,               'expected 3 users';
+  ASSERT (SELECT count(*) FROM trips) = 5,               'expected 5 trips';
+END $$;
+
+-- 2. Independent read/write permissions are preserved. ----------------------
+DO $$
+BEGIN
+  ASSERT (SELECT can_read AND NOT can_write FROM vehicle_permissions
+          WHERE user_id = 'user-reader'
+            AND vehicle_id = '11111111-1111-1111-1111-111111111111'),
+         'user-reader should be read-only';
+  ASSERT (SELECT can_write AND NOT can_read FROM vehicle_permissions
+          WHERE user_id = 'user-writer'
+            AND vehicle_id = '11111111-1111-1111-1111-111111111111'),
+         'user-writer should be write-only';
+END $$;
+
+-- 3. A trip cannot use a class that is not defined on its vehicle. -----------
+--    (Equivalent to the Firestore rule: trip.class in vehicle.classes.)
+DO $$
+BEGIN
+  INSERT INTO trips (vehicle_id, class, odo, recorded_at)
+  VALUES ('11111111-1111-1111-1111-111111111111', 'NotSpecified', 999.0, now());
+  RAISE EXCEPTION 'expected a foreign_key_violation for an undefined class';
+EXCEPTION
+  WHEN foreign_key_violation THEN
+    NULL; -- expected
+END $$;
+
+-- 4. The odometer is unique per vehicle. ------------------------------------
+DO $$
+BEGIN
+  INSERT INTO trips (vehicle_id, class, odo, recorded_at)
+  VALUES ('11111111-1111-1111-1111-111111111111', 'Business', 10.0, now());
+  RAISE EXCEPTION 'expected a unique_violation for a duplicate odo';
+EXCEPTION
+  WHEN unique_violation THEN
+    NULL; -- expected
+END $$;
+
+-- 5. A permission row must grant at least one capability. -------------------
+DO $$
+BEGIN
+  INSERT INTO vehicle_permissions (vehicle_id, user_id, can_read, can_write)
+  VALUES ('22222222-2222-2222-2222-222222222222', 'user-nobody', FALSE, FALSE);
+  RAISE EXCEPTION 'expected a check_violation for an empty permission';
+EXCEPTION
+  WHEN check_violation THEN
+    NULL; -- expected
+END $$;
+
+-- 6. Deleting a vehicle cascades to its classes, permissions and trips. ------
+DO $$
+DECLARE
+  v UUID := gen_random_uuid();
+BEGIN
+  INSERT INTO vehicles (id, name) VALUES (v, 'temp');
+  INSERT INTO vehicle_classes (vehicle_id, class, position) VALUES (v, 'X', 0);
+  INSERT INTO vehicle_permissions (vehicle_id, user_id, can_read) VALUES (v, 'u', TRUE);
+  INSERT INTO trips (vehicle_id, class, odo, recorded_at) VALUES (v, 'X', 1.0, now());
+  DELETE FROM vehicles WHERE id = v;
+  ASSERT (SELECT count(*) FROM vehicle_classes WHERE vehicle_id = v) = 0,     'classes not cascaded';
+  ASSERT (SELECT count(*) FROM vehicle_permissions WHERE vehicle_id = v) = 0, 'permissions not cascaded';
+  ASSERT (SELECT count(*) FROM trips WHERE vehicle_id = v) = 0,               'trips not cascaded';
+END $$;
+
+\echo 'All database smoke tests passed.'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
     "build": "parcel build",
     "deploy:rules": "firebase deploy --only firestore:rules",
     "deploy:rules:prod": "firebase --project records-classificater deploy --only firestore:rules",
-    "test": "firebase emulators:exec jest"
+    "test": "firebase emulators:exec jest",
+    "db:schema": "psql \"$POSTGRES_URL\" -v ON_ERROR_STOP=1 -f db/schema.sql",
+    "db:seed": "psql \"$POSTGRES_URL\" -v ON_ERROR_STOP=1 -f db/seed.sql",
+    "db:reset": "psql \"$POSTGRES_URL\" -v ON_ERROR_STOP=1 -f db/reset.sql -f db/schema.sql -f db/seed.sql",
+    "db:test": "psql \"$POSTGRES_URL\" -v ON_ERROR_STOP=1 -f db/schema.sql -f db/seed.sql -f db/test/smoke.sql"
   },
   "source": "src/index.html"
 }


### PR DESCRIPTION
## 概要

インフラを Vercel に乗り換えるにあたり、Firestore のデータモデルをリレーショナルに翻訳した Vercel Postgres 用のスキーマ・テスト用シードデータ・CI を追加します。

スコープは **スキーマ／シード／CI** に限定しています。アプリ本体の Firebase → Postgres 書き換えや既存の Firebase デプロイワークフローの撤去は影響範囲が大きいため、本 PR には含めていません。

## データモデルの対応

| Firestore | Postgres |
| --- | --- |
| `users/{uid}` (`state.vehicle`) | `users` (`current_vehicle_id`) |
| `vehicles/{vid}` | `vehicles` + `vehicle_classes` + `vehicle_permissions` |
| `vehicles/{vid}/trips/{tid}` | `trips` (`recorded_at`) |

### 設計上のポイント

- **権限の独立性を維持** — `permissions.read` / `write` 配列を `can_read` / `can_write` の独立した boolean 列に。write-only ユーザーが read 不可という元のセキュリティルールを保持。
- **クラスの整合性を FK で強制** — `classes` 配列を順序付き `vehicle_classes` テーブルに正規化し、`trips(vehicle_id, class)` の複合 FK で「trip.class は車両のクラスのいずれか」を保証（元のルールと等価）。
- **ユーザー ID は認証 uid の `TEXT`** — `vehicle_permissions.user_id` は `users` への FK にしない（未ログインユーザーへの共有が Firestore 同様に可能）。

## 追加ファイル

- `db/schema.sql` — テーブル定義（drop なし、本番の新規 DB に一度適用して安全）
- `db/seed.sql` — ルールテストの fixture を再現した決定的なシードデータ
- `db/reset.sql` — 開発／CI 用の再初期化
- `db/test/smoke.sql` — スキーマ制約とシード整合性のアサーション
- `.github/workflows/database.yml` — `db/**` 変更時に `postgres:16` を起動し schema 適用 → seed → smoke テスト → reset 再適用の冪等性を検証
- `package.json` — `POSTGRES_URL`（Vercel Postgres が供給する変数名）を使う `db:schema` / `db:seed` / `db:reset` / `db:test`
- `db/README.md` — 使い方とデータモデルの対応表

## 動作確認

ローカルの PostgreSQL 16 で schema 適用・seed 投入・smoke テスト・reset 再適用まですべて成功を確認済みです。

> 生 SQL 構成にしています（Vercel Postgres の `@vercel/postgres` がタグ付き SQL を前提とするため）。ORM／マイグレーションツールを載せる方針でも組み直せます。

https://claude.ai/code/session_01MnBCPduqCP95vosKY2TU9B

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnBCPduqCP95vosKY2TU9B)_