### PR TITLE
UI調整: 削除ボタンの控えめ化・車両追加ボタンの明確化

### DIFF
--- a/src/sections/AccountSettings.tsx
+++ b/src/sections/AccountSettings.tsx
@@ -74,9 +74,8 @@ export default function AccountSettings({ onClose }: { onClose: () => void }) {
             ログアウト
           </button>
 
-          <div className="border-t border-gray-100 pt-3">
-            <p className="text-xs text-gray-500 mb-1">危険な操作</p>
-            <DeleteAccount className="w-full border-2 border-red-300 text-red-700 rounded-xl py-2.5 font-medium active:bg-red-50" />
+          <div className="border-t border-gray-100 pt-3 text-center">
+            <DeleteAccount className="text-xs text-gray-400 underline active:text-red-600" />
           </div>
 
           <button

--- a/src/sections/VehicleSettings.tsx
+++ b/src/sections/VehicleSettings.tsx
@@ -168,8 +168,8 @@ export default function VehicleSettings({
         ) : (
           <div className="space-y-5">
             {/* 設定する車両の選択 ＋ 追加 */}
-            <div className="flex items-end gap-2">
-              <label className="grow min-w-0">
+            <div>
+              <label className="block">
                 <span className="text-xs font-medium text-gray-600">設定する車両</span>
                 {vehicles.length ? (
                   <select
@@ -182,16 +182,15 @@ export default function VehicleSettings({
                     ))}
                   </select>
                 ) : (
-                  <p className="text-sm text-gray-500 py-2">車両がありません。右のボタンから追加してください。</p>
+                  <p className="text-sm text-gray-500 py-2">車両がありません。下のボタンから追加してください。</p>
                 )}
               </label>
               <button
                 type="button"
                 onClick={handleAddVehicle}
-                aria-label="車両を追加"
-                className="shrink-0 w-11 h-11 flex items-center justify-center rounded-lg border border-gray-300 text-lime-700 text-2xl font-light active:bg-gray-100"
+                className="mt-2 text-sm text-lime-700 font-medium active:text-lime-800"
               >
-                ＋
+                ＋ 車両を追加
               </button>
             </div>
 


### PR DESCRIPTION
PR #440（Vercel + Neon + Clerk 移行）のブランチに対する UI 微調整です。

## 変更内容

### 1. アカウント削除ボタン（`src/sections/AccountSettings.tsx`）
赤枠・全幅・太字の目立つボタンを、**小さめ文字・ボーダーなし**の控えめなテキストリンクに変更。削除は破壊的操作なので押下時のみ赤くなる程度に抑制し、目立ちすぎていた「危険な操作」見出しも削除（実行時の確認ダイアログは従来どおり）。

### 2. 車両追加ボタン（`src/sections/VehicleSettings.tsx`）
セレクタ横の「＋」アイコンのみのボタンを、セレクタ下に配置した**「＋ 車両を追加」の文字入りボタン**に変更。同画面の「＋ 走行種別を追加」「＋ 共有相手を追加」と同じデザインパターンに統一し、何のボタンか分かりやすくした。

---
※ 再デプロイ後の再ログインについては、コードではなくデプロイ/Clerk インスタンス構成（固定ドメイン + production インスタンス）で解消できる見込みのため、本 PR には含めていません。

https://claude.ai/code/session_01JNqktt6ZWmDg4rW73RvUSn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNqktt6ZWmDg4rW73RvUSn)_